### PR TITLE
Path to Docker socket can now be set on the traefik router.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ definition.
 > **Note:** The name of the folder must match the name specified in the service
 > definition.
 
+The definition YAML files are all processed as Jinja templates.  Where
+specified, Jinja variable syntax of the form ``{{ some_variable }}`` can be used
+to inject values during processing.
+
 ### Service Group
 
 All of a host's services are enumerated by a service group.  The group
@@ -66,13 +70,6 @@ services:
     - one_service
     - another_service
 ```
-The configuration file is processed as a Jinja template.  This allows
-information about the host to be injected into the routing configuration using
-Jinja's variables expansion, e.g., `{{ some_variable }}`.
-
-| Variable          | Description |
-| ------------------| ----------- |
-| `service.network` | The name of the internal container network. |
 
 ### Service Definition
 
@@ -117,9 +114,38 @@ volumes:
     internal-storage: /storage
 ```
 
-Information about the service group is provided to each definition in the form
-of Jinja variables.
+The following variables are defined when a service definition is being
+processed:
 
 | Variable          | Description |
 | ------------------| ----------- |
 | `service.folder`  | The path to the service definition folder. |
+
+## Routers
+
+Routers are used to route external traffic into the internal container network.
+The choice of router is set by the `router` property in the
+[service group definition](#service-group).
+
+Each router has a configuration file specified by the `config` property that is
+processed as a Jinja template.  The following variables are defined when the
+group definition is being processed:
+
+| Variable          | Description |
+| ------------------| ----------- |
+| `service.network` | The name of the internal container network. |
+
+### Traefik
+
+The `traefik` router uses [traefik proxy](https://doc.traefik.io/traefik/) for
+passing information to and from the external network to the service containers.
+There is minimal configuration within the service definition beyond ensuring the
+dashboard can be accessed.  The router should be configured using either a YAML
+or TOML [configuration file](https://doc.traefik.io/traefik/providers/file/).
+
+The service itself has the following configuraiton arguments:
+
+| Argument | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `map-socket` | `bool` | `true` | Map an external Docker socket into the Traefik container as a volume mount. |
+| `socket` | `string` | `/var/run/docker.sock` | Path to the Docker socket Traefik will be using. |

--- a/src/gantry/build.py
+++ b/src/gantry/build.py
@@ -62,7 +62,7 @@ def _build_compose_file(service_group: ServiceGroupDefinition) -> ComposeFile:
 
     services = map(
         router.register_service,
-        [router.generate_service()] + list(service_group)
+        [router.generate_service(service_group.router.args)] + list(service_group)
     )
 
     service_mapping: dict[str, ComposeService] = {}

--- a/src/gantry/routers/provider.py
+++ b/src/gantry/routers/provider.py
@@ -7,13 +7,13 @@ class RoutingProvider(ABC):
     '''Defines the routing provider for the managed services.'''
 
     @abstractmethod
-    def generate_service(self) -> ServiceDefinition:
+    def generate_service(self, args: dict) -> ServiceDefinition:
         '''Generate the service definition for the routing provider.
 
         Parameters
         ----------
-        config : Path
-            relative path to the configuration file
+        args : dict
+            optional arguments that the service can use to configure itself
 
         Returns
         -------

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -13,7 +13,7 @@ SERVICE_FILE = 'proxy-service.yml'
 class TraefikRoutingProvider(RoutingProvider):
     '''Configures Traefik as the services' routing provider.'''
 
-    def generate_service(self) -> ServiceDefinition:
+    def generate_service(self, args: dict) -> ServiceDefinition:
         yaml = YAML()
         with importlib.resources.open_text(__package__, SERVICE_FILE) as f:
             return ServiceDefinition(definition=yaml.load(f))

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -1,4 +1,7 @@
 import importlib.resources
+from io import StringIO
+
+from jinja2 import Environment
 
 from ruamel.yaml import YAML
 
@@ -7,16 +10,30 @@ from .. import RoutingProvider
 from ...services import ServiceDefinition
 
 
+DOCKER_SOCKET = '/var/run/docker.sock'
 SERVICE_FILE = 'proxy-service.yml'
+
+
+def _get_service_file() -> str:
+    with importlib.resources.open_text(__package__, SERVICE_FILE) as f:
+        return f.read()
 
 
 class TraefikRoutingProvider(RoutingProvider):
     '''Configures Traefik as the services' routing provider.'''
 
     def generate_service(self, args: dict) -> ServiceDefinition:
+        template_args = {
+            'map_socket': args.get('map-socket', True),
+            'socket_path': args.get('socket', DOCKER_SOCKET)
+        }
+
+        env = Environment()
+        output = env.from_string(_get_service_file()).render(**template_args)
+
         yaml = YAML()
-        with importlib.resources.open_text(__package__, SERVICE_FILE) as f:
-            return ServiceDefinition(definition=yaml.load(f))
+        with StringIO(output) as s:
+            return ServiceDefinition(definition=yaml.load(s))
 
     def register_service(self, service: ServiceDefinition) -> ServiceDefinition:
         entrypoint = service.entrypoint

--- a/src/gantry/routers/traefik/proxy-service.yml
+++ b/src/gantry/routers/traefik/proxy-service.yml
@@ -5,9 +5,11 @@ entrypoint:
     - /api
     - /dashboard
 files:
+  {% if map_socket %}
   docker-socket:
     internal: /var/run/docker.sock
-    external: /var/run/docker.sock
+    external: "{{ socket_path }}"
+  {% endif %}
   config-file:
     internal: /traefik.yml
     external: ./traefik.yml

--- a/src/gantry/schemas/service_group.json
+++ b/src/gantry/schemas/service_group.json
@@ -27,6 +27,10 @@
                 "config": {
                     "description": "Relative path to the provider's configuration file.  This is treated as a Jinja2 template.",
                     "type": "string"
+                },
+                "args": {
+                    "description": "Provider-specific arguments used when generating its service definition.",
+                    "type": "object"
                 }
             },
             "additionalProperties": false,

--- a/src/gantry/services.py
+++ b/src/gantry/services.py
@@ -225,6 +225,7 @@ class ServiceGroupDefinition(_ServiceDefinitionBase):
     class RouterInfo(NamedTuple):
         provider: str
         config: TemplateReference
+        args: dict[str, object] | None
 
     def __init__(self, folder: Path) -> None:
         super().__init__(Schema.SERVICE_GROUP, folder=folder)
@@ -242,7 +243,8 @@ class ServiceGroupDefinition(_ServiceDefinitionBase):
 
         router = self._definition['router']
         config = TemplateReference(self.folder, router['config'])
-        return ServiceGroupDefinition.RouterInfo(router['provider'], config)
+        args = self._definition.get('args')
+        return ServiceGroupDefinition.RouterInfo(router['provider'], config, args)
 
     @property
     def services(self) -> dict[str, ServiceDefinition]:

--- a/src/gantry/services.py
+++ b/src/gantry/services.py
@@ -243,7 +243,7 @@ class ServiceGroupDefinition(_ServiceDefinitionBase):
 
         router = self._definition['router']
         config = TemplateReference(self.folder, router['config'])
-        args = self._definition.get('args', {})
+        args = router.get('args', {})
         return ServiceGroupDefinition.RouterInfo(router['provider'], config, args)
 
     @property

--- a/src/gantry/services.py
+++ b/src/gantry/services.py
@@ -225,7 +225,7 @@ class ServiceGroupDefinition(_ServiceDefinitionBase):
     class RouterInfo(NamedTuple):
         provider: str
         config: TemplateReference
-        args: dict[str, object] | None
+        args: dict
 
     def __init__(self, folder: Path) -> None:
         super().__init__(Schema.SERVICE_GROUP, folder=folder)
@@ -243,7 +243,7 @@ class ServiceGroupDefinition(_ServiceDefinitionBase):
 
         router = self._definition['router']
         config = TemplateReference(self.folder, router['config'])
-        args = self._definition.get('args')
+        args = self._definition.get('args', {})
         return ServiceGroupDefinition.RouterInfo(router['provider'], config, args)
 
     @property

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+import pytest
+from pytest import Config
+
+
+@pytest.fixture()
+def samples_folder(pytestconfig: Config) -> Path:
+    return pytestconfig.invocation_params.dir / 'test' / 'samples'

--- a/test/samples/traefik-custom-socket/service.yml
+++ b/test/samples/traefik-custom-socket/service.yml
@@ -1,0 +1,9 @@
+name: traefik-custom-socket
+network: test
+router:
+  provider: traefik
+  config: traefik.yml
+  args:
+    socket: /run/users/1001/docker.sock
+services:
+  - service

--- a/test/samples/traefik-custom-socket/service/service.yml
+++ b/test/samples/traefik-custom-socket/service/service.yml
@@ -1,0 +1,3 @@
+name: service
+entrypoint: /
+image: hello-world:latest

--- a/test/samples/traefik-custom-socket/traefik.yml
+++ b/test/samples/traefik-custom-socket/traefik.yml
@@ -1,0 +1,3 @@
+entrypoints:
+  web:
+    address: ":80"

--- a/test/samples/traefik-default/service.yml
+++ b/test/samples/traefik-default/service.yml
@@ -1,0 +1,7 @@
+name: traefik-default
+network: test
+router:
+  provider: traefik
+  config: traefik.yml
+services:
+  - service

--- a/test/samples/traefik-default/service/service.yml
+++ b/test/samples/traefik-default/service/service.yml
@@ -1,0 +1,3 @@
+name: service
+entrypoint: /
+image: hello-world:latest

--- a/test/samples/traefik-default/traefik.yml
+++ b/test/samples/traefik-default/traefik.yml
@@ -1,0 +1,3 @@
+entrypoints:
+  web:
+    address: ":80"

--- a/test/test_traefik_router.py
+++ b/test/test_traefik_router.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gantry import cli
+
+import pytest
+
+from ruamel.yaml import YAML
+
+
+@pytest.mark.parametrize(
+    ('sample', 'expected'),
+    [
+        ('traefik-default', '/var/run/docker.sock'),
+        ('traefik-custom-socket', '/run/users/1001/docker.sock')
+    ]
+)
+def test_router_args(sample: str, expected: str, samples_folder: Path, tmp_path: Path):
+    runner = CliRunner()
+    default_example = samples_folder / sample
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli.main, ['build-compose', '-s', default_example.as_posix()])
+        compose_file = Path(td) / 'services.docker' / 'docker-compose.yml'
+        assert result.exit_code == 0
+        assert compose_file.exists
+
+        yaml = YAML()
+        with compose_file.open('rt') as f:
+            compose_spec = yaml.load(f)
+
+        volumes = compose_spec['services']['proxy']['volumes']
+        assert volumes[0] == f'{expected}:/var/run/docker.sock:ro'


### PR DESCRIPTION
Allow the path to the external Docker socket to be set on the traefik router.  A new optional `args` property was added to the service group definition to make this possible.  E.g.,

```yaml
router:
  provider: traefik
  config: traefik.yml

  # This will allow the socket at the path below to be mounted instead of
  # /var/run/docker.sock.
  args:
    socket: /run/users/1001/docker.sock
```