### PR TITLE
Assume build context when no container image is specified.

### DIFF
--- a/src/gantry/build.py
+++ b/src/gantry/build.py
@@ -130,7 +130,7 @@ def _convert_to_compose_service(service: ServiceDefinition,
 
     if image := service.image:
         compose_service['image'] = image
-    elif build_args := service.build_args:
+    else:
         if folder := service.folder:
             context = folder.relative_to(folder.parent).as_posix()
         else:
@@ -138,9 +138,11 @@ def _convert_to_compose_service(service: ServiceDefinition,
 
         compose_service['image'] = ':'.join([service.name, tag])
         compose_service['build'] = {
-            'args': build_args,
             'context': context
         }
+
+        if build_args := service.build_args:
+            compose_service['build']['args'] = build_args
 
     compose_service['environment'] = {var.key: str(var.value) for var in service.environment}
     compose_service['restart'] = 'unless-stopped'

--- a/src/gantry/schemas/service.json
+++ b/src/gantry/schemas/service.json
@@ -157,10 +157,6 @@
         }
     },
     "required": ["name"],
-    "anyOf": [
-        {"required": ["build-args"]},
-        {"required": ["image"]}
-    ],
     "not": {
         "anyOf": [
             {"required": ["image", "build-args"]}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Callable
 
+import click
 from click.testing import CliRunner
 
 from gantry import cli
@@ -21,6 +22,8 @@ def compile_compose_file(samples_folder: Path, tmp_path: Path) -> Callable[[str,
         with runner.isolated_filesystem(temp_dir=tmp_path) as td:
             result = runner.invoke(cli.main, ['build-compose', '-s', default_example.as_posix()])
             compose_file = Path(td) / 'services.docker' / 'docker-compose.yml'
+
+            click.echo(result.stdout)
             assert result.exit_code == 0
             assert compose_file.exists
 

--- a/test/samples/service-definition/build-args/no-args/service.yml
+++ b/test/samples/service-definition/build-args/no-args/service.yml
@@ -1,0 +1,1 @@
+name: no-args

--- a/test/samples/service-definition/build-args/service.yml
+++ b/test/samples/service-definition/build-args/service.yml
@@ -1,0 +1,8 @@
+name: build-args
+network: test
+router:
+  provider: traefik
+  config: traefik.yml
+services:
+  - no-args
+  - with-args

--- a/test/samples/service-definition/build-args/traefik.yml
+++ b/test/samples/service-definition/build-args/traefik.yml
@@ -1,0 +1,3 @@
+entryPoints:
+  web:
+    address: ":80"

--- a/test/samples/service-definition/build-args/with-args/service.yml
+++ b/test/samples/service-definition/build-args/with-args/service.yml
@@ -1,0 +1,4 @@
+name: default
+build-args:
+  foo: 1
+  bar: 2

--- a/test/samples/service-definition/build-args/with-args/service.yml
+++ b/test/samples/service-definition/build-args/with-args/service.yml
@@ -1,4 +1,4 @@
-name: default
+name: with-args
 build-args:
   foo: 1
   bar: 2

--- a/test/test_service_definition.py
+++ b/test/test_service_definition.py
@@ -35,6 +35,7 @@ def test_entrypoints(service: str, expected_rule: set[str], expected_port: str,
                      compile_compose_file: CompileFn):
     compose_file = compile_compose_file('service-definition', 'entrypoints')
     path_rule, port_rule = _get_routing_rule(compose_file, service)
+    assert compose_file['services'][service]['image'] == 'hello-world:latest'
     assert path_rule == expected_rule
     assert port_rule == expected_port
 

--- a/test/test_service_definition.py
+++ b/test/test_service_definition.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from gantry._compose_spec import ComposeFile
+from gantry._compose_spec import ComposeBuild, ComposeFile
 
 import pytest
 
@@ -8,9 +8,9 @@ import pytest
 CompileFn = Callable[[str, str], ComposeFile]
 
 
-def _get_build_args(compose_spec: ComposeFile, service: str) -> dict[str, str | int]:
+def _get_build_info(compose_spec: ComposeFile, service: str) -> ComposeBuild:
     assert 'build' in compose_spec['services'][service]
-    return compose_spec['services'][service]['build'].get('args', {})
+    return compose_spec['services'][service]['build']
 
 
 def _get_routing_rule(compose_spec: ComposeFile, service: str) -> tuple[set[str], int | None]:
@@ -49,5 +49,6 @@ def test_entrypoints(service: str, expected_rule: set[str], expected_port: str,
 def test_build_args(service: str, expected_args: dict[str, str | int],
                     compile_compose_file: CompileFn):
     compose_file = compile_compose_file('service-definition', 'build-args')
-    build_args = _get_build_args(compose_file, service)
-    assert build_args == expected_args
+    build_info = _get_build_info(compose_file, service)
+    assert build_info.get('args', {}) == expected_args
+    assert build_info['context'] == service

--- a/test/test_service_definition.py
+++ b/test/test_service_definition.py
@@ -13,9 +13,12 @@ def _get_build_args(compose_spec: ComposeFile, service: str) -> dict[str, str | 
     return compose_spec['services'][service]['build'].get('args', {})
 
 
-def _get_routing_rule(compose_spec: ComposeFile, service: str) -> tuple[str, int | None]:
+def _get_routing_rule(compose_spec: ComposeFile, service: str) -> tuple[set[str], int | None]:
     labels = compose_spec['services'][service]['labels']
-    path_rule = labels[f'traefik.http.routers.{service}.rule']
+    path_rule = set(
+        rule.strip()
+        for rule in labels[f'traefik.http.routers.{service}.rule'].split('||')
+    )
     port_rule = labels.get(f'traefik.http.services.{service}.loadbalancer.server.port')
     return (path_rule, port_rule)
 
@@ -23,12 +26,12 @@ def _get_routing_rule(compose_spec: ComposeFile, service: str) -> tuple[str, int
 @pytest.mark.parametrize(
     ('service', 'expected_rule', 'expected_port'),
     [
-        ('complex-entrypoint', 'PathPrefix(`/foo`) || PathPrefix(`/bar`)', 8080),
-        ('default', 'PathPrefix(`/default`)', 80),
-        ('string-entrypoint', 'PathPrefix(`/my-service`)', 80)
+        ('complex-entrypoint', {'PathPrefix(`/foo`)', 'PathPrefix(`/bar`)'}, 8080),
+        ('default', {'PathPrefix(`/default`)'}, 80),
+        ('string-entrypoint', {'PathPrefix(`/my-service`)'}, 80)
     ]
 )
-def test_entrypoints(service: str, expected_rule: str, expected_port: str,
+def test_entrypoints(service: str, expected_rule: set[str], expected_port: str,
                      compile_compose_file: CompileFn):
     compose_file = compile_compose_file('service-definition', 'entrypoints')
     path_rule, port_rule = _get_routing_rule(compose_file, service)
@@ -45,6 +48,6 @@ def test_entrypoints(service: str, expected_rule: str, expected_port: str,
 )
 def test_build_args(service: str, expected_args: dict[str, str | int],
                     compile_compose_file: CompileFn):
-    compose_file = compile_compose_file('service_definition', 'build-args')
+    compose_file = compile_compose_file('service-definition', 'build-args')
     build_args = _get_build_args(compose_file, service)
     assert build_args == expected_args


### PR DESCRIPTION
Specifying the build arguments is no longer required when the service builds its own container.  If no `build` or `image` property is provided then gantry will assume that the service will be building its own container.  Both properties are still mutually exclusive and the schema parser will still produce an error if this occurs.