### PR TITLE
No longer using a hard-coded file name for the Traefik configuration file.

### DIFF
--- a/src/gantry/build.py
+++ b/src/gantry/build.py
@@ -59,10 +59,12 @@ def _build_compose_file(service_group: ServiceGroupDefinition) -> ComposeFile:
         raise ComposeServiceBuildError(f'Unknown routing provider `{service_group.router.provider}`.')  # noqa: E501
 
     router = routers.PROVIDERS[service_group.router.provider]()
+    router_args = service_group.router.args.copy()
+    router_args['_config-file'] = service_group.router.config.path.name
 
     services = map(
         router.register_service,
-        [router.generate_service(service_group.router.args)] + list(service_group)
+        [router.generate_service(router_args)] + list(service_group)
     )
 
     service_mapping: dict[str, ComposeService] = {}

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -24,6 +24,8 @@ class TraefikRoutingProvider(RoutingProvider):
 
     def generate_service(self, args: dict) -> ServiceDefinition:
         template_args = {
+            'config_file': args['_config-file'],
+            'enable_tls': args.get('enable-tls', False),
             'map_socket': args.get('map-socket', True),
             'socket_path': args.get('socket', DOCKER_SOCKET)
         }

--- a/src/gantry/routers/traefik/proxy-service.yml
+++ b/src/gantry/routers/traefik/proxy-service.yml
@@ -12,7 +12,7 @@ files:
   {% endif %}
   config-file:
     internal: /traefik.yml
-    external: ./traefik.yml
+    external: "./{{ config_file }}"
 service-ports:
   http:
     internal: 80

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,18 +18,37 @@ def compile_compose_file(samples_folder: Path, tmp_path: Path) -> Callable[[str,
 
     def _run_command(folder: str, sample: str) -> ComposeFile:
         runner = CliRunner()
-        default_example = samples_folder / folder / sample
+        sample_path = samples_folder / folder / sample
         with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-            result = runner.invoke(cli.main, ['build-compose', '-s', default_example.as_posix()])
+            result = runner.invoke(cli.main, ['build-compose', '-s', sample_path.as_posix()])
             compose_file = Path(td) / 'services.docker' / 'docker-compose.yml'
 
             click.echo(result.stdout)
             assert result.exit_code == 0
-            assert compose_file.exists
+            assert compose_file.exists()
 
             yaml = YAML()
             with compose_file.open('rt') as f:
                 return yaml.load(f)
+
+    return _run_command
+
+
+@pytest.fixture()
+def compile_services(samples_folder: Path, tmp_path: Path) -> Callable[[str, str], Path]:
+
+    def _run_command(folder: str, sample: str) -> Path:
+        runner = CliRunner()
+        sample_path = samples_folder / folder / sample
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            result = runner.invoke(cli.main, ['build-compose', '-s', sample_path.as_posix()])
+            output_path = Path(td) / 'services.docker'
+
+            click.echo(result.stdout)
+            assert result.exit_code == 0
+            assert (output_path / 'docker-compose.yml').exists()
+
+            return output_path
 
     return _run_command
 

--- a/test/samples/router/traefik-custom-config/service.yml
+++ b/test/samples/router/traefik-custom-config/service.yml
@@ -1,0 +1,7 @@
+name: traefik-default
+network: test
+router:
+  provider: traefik
+  config: traefik-custom.yml
+services:
+  - service

--- a/test/samples/router/traefik-custom-config/service/service.yml
+++ b/test/samples/router/traefik-custom-config/service/service.yml
@@ -1,0 +1,3 @@
+name: service
+entrypoint: /
+image: hello-world:latest

--- a/test/samples/router/traefik-custom-config/traefik-custom.yml
+++ b/test/samples/router/traefik-custom-config/traefik-custom.yml
@@ -1,0 +1,8 @@
+entryPoints:
+  web:
+    address: ":80"
+
+providers:
+  docker:
+    watch: true
+    network: "{{ service.network }}"

--- a/test/test_traefik_router.py
+++ b/test/test_traefik_router.py
@@ -1,8 +1,14 @@
+from pathlib import Path
 from typing import Callable
 
 from gantry._compose_spec import ComposeFile
 
+from ruamel.yaml import YAML
+
 import pytest
+
+CompileFn = Callable[[str, str], ComposeFile]
+ServicesFn = Callable[[str, str], Path]
 
 
 @pytest.mark.parametrize(
@@ -18,3 +24,25 @@ def test_router_args(sample: str, expected: str,
     compose_spec = compile_compose_file('router', sample)
     volumes = compose_spec['services']['proxy']['volumes']
     assert volumes[0] == f'{expected}:/var/run/docker.sock:ro'
+
+
+def test_router_config_render(compile_services: ServicesFn):
+    '''Check that the router's configuration is rendered correctly.'''
+    output_path = compile_services('router', 'traefik-custom-config')
+    assert (output_path / 'traefik-custom.yml').exists()
+
+    # Check that the traefik file sets the network correctly.
+    reader = YAML()
+    with (output_path / 'traefik-custom.yml').open('rt') as f:
+        traefik_file = reader.load(f)
+
+    network = traefik_file['providers']['docker']['network']
+    assert network == 'test'
+
+    # Check that the compose file references the correct traefik file.
+    reader = YAML()
+    with (output_path / 'docker-compose.yml').open('rt') as f:
+        compose_spec: ComposeFile = reader.load(f)
+
+    volumes = compose_spec['services']['proxy']['volumes']
+    assert volumes[1] == './traefik-custom.yml:/traefik.yml:ro'


### PR DESCRIPTION
This fixes a bug where the name of the Traefik configuration file was set to `traefik.yml` in the generated `docker-compose.yml` file.  The value of the `config` property within the service group definition is now used correctly during the compilation process.