### PR TITLE
Add support for Traefik dynamic configuration with a file provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,15 @@ group definition is being processed:
 The `traefik` router uses [traefik proxy](https://doc.traefik.io/traefik/) for
 passing information to and from the external network to the service containers.
 There is minimal configuration within the service definition beyond ensuring the
-dashboard can be accessed.  The router should be configured using either a YAML
-or TOML [configuration file](https://doc.traefik.io/traefik/providers/file/).
+dashboard can be accessed.  The router's `config` property points to a traefik
+[static configuration file](https://doc.traefik.io/traefik/getting-started/configuration-overview/#configuration-file).
+The `dynamic-config` argument (see below) can be used for additional
+configuration.
 
 The service itself has the following configuraiton arguments:
 
 | Argument | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
+| `dynamic-config` | `string` | empty string | Specify a folder where any [dynamic configuration files](https://doc.traefik.io/traefik/providers/file/) will be located. |
 | `map-socket` | `bool` | `true` | Map an external Docker socket into the Traefik container as a volume mount. |
 | `socket` | `string` | `/var/run/docker.sock` | Path to the Docker socket Traefik will be using. |

--- a/src/gantry/build.py
+++ b/src/gantry/build.py
@@ -181,6 +181,10 @@ def _copy_services_resources(service_group: ServiceGroupDefinition, folder: Path
     folder : Path
         path to output folder
     '''
+    if services_folder := service_group.folder:
+        router = routers.PROVIDERS[service_group.router.provider]()
+        router.copy_resources(services_folder, folder, service_group.router.args)
+
     for service in service_group:
         if service.folder is None:
             break

--- a/src/gantry/routers/provider.py
+++ b/src/gantry/routers/provider.py
@@ -1,10 +1,27 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from ..services import ServiceDefinition
 
 
 class RoutingProvider(ABC):
     '''Defines the routing provider for the managed services.'''
+
+    def copy_resources(self, service_folder: Path, output_folder: Path, args: dict):
+        '''Copy any resources need by the routing providing.
+
+        The default implementation does nothing.  A provider can override this
+        method if it needs to copy files when certain arguments are set.
+
+        Parameters
+        ----------
+        service_folder : Path
+            location of the services group definition folder
+        output_folder : Path
+            location of the services output folder
+        args : dict
+            optional arguments that the service can use to configure itself
+        '''
 
     @abstractmethod
     def generate_service(self, args: dict) -> ServiceDefinition:

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -41,7 +41,6 @@ class TraefikRoutingProvider(RoutingProvider):
         template_args = {
             'config_file': args['_config-file'],
             'dynamic_config': args.get('dynamic-config'),
-            'enable_tls': args.get('enable-tls', False),
             'map_socket': args.get('map-socket', True),
             'socket_path': args.get('socket', DOCKER_SOCKET)
         }

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -22,11 +22,19 @@ def _get_service_file() -> str:
         return f.read()
 
 
+def _get_dynamic_config(args: dict) -> Path | None:
+    value: str | None = args.get('dynamic-config')
+    if value is None:
+        return None
+    else:
+        return Path(value)
+
+
 class TraefikRoutingProvider(RoutingProvider):
     '''Configures Traefik as the services' routing provider.'''
 
     def copy_resources(self, services_folder: Path, output_folder: Path, args: dict):
-        dynamic_config: str | None = args.get('dynamic-config')
+        dynamic_config = _get_dynamic_config(args)
         if dynamic_config is None:
             return
 
@@ -40,7 +48,7 @@ class TraefikRoutingProvider(RoutingProvider):
     def generate_service(self, args: dict) -> ServiceDefinition:
         template_args = {
             'config_file': args['_config-file'],
-            'dynamic_config': args.get('dynamic-config'),
+            'dynamic_config': _get_dynamic_config(args),
             'map_socket': args.get('map-socket', True),
             'socket_path': args.get('socket', DOCKER_SOCKET)
         }

--- a/src/gantry/routers/traefik/_provider.py
+++ b/src/gantry/routers/traefik/_provider.py
@@ -40,6 +40,7 @@ class TraefikRoutingProvider(RoutingProvider):
     def generate_service(self, args: dict) -> ServiceDefinition:
         template_args = {
             'config_file': args['_config-file'],
+            'dynamic_config': args.get('dynamic-config'),
             'enable_tls': args.get('enable-tls', False),
             'map_socket': args.get('map-socket', True),
             'socket_path': args.get('socket', DOCKER_SOCKET)

--- a/src/gantry/routers/traefik/proxy-service.yml
+++ b/src/gantry/routers/traefik/proxy-service.yml
@@ -10,7 +10,12 @@ files:
     internal: /var/run/docker.sock
     external: "{{ socket_path }}"
   {% endif %}
-  config-file:
+  {% if dynamic_config %}
+  dynamic-config:
+    internal: "/{{ dynamic_config.name }}"
+    external: "./{{ dynamic_config.name }}"
+  {% endif %}
+  static-config:
     internal: /traefik.yml
     external: "./{{ config_file }}"
 service-ports:

--- a/test/samples/router/traefik-dynamic-config/configuration/certificates.yml
+++ b/test/samples/router/traefik-dynamic-config/configuration/certificates.yml
@@ -1,0 +1,3 @@
+# This file would contain the actual TLS configuration, namely the CA cert and a
+# private key.
+some-config: true

--- a/test/samples/router/traefik-dynamic-config/configuration/certificates.yml
+++ b/test/samples/router/traefik-dynamic-config/configuration/certificates.yml
@@ -1,3 +1,6 @@
 # This file would contain the actual TLS configuration, namely the CA cert and a
 # private key.
-some-config: true
+tls:
+  certificates:
+    - certFile: my.cert
+      keyFile: my.key

--- a/test/samples/router/traefik-dynamic-config/service.yml
+++ b/test/samples/router/traefik-dynamic-config/service.yml
@@ -1,0 +1,9 @@
+name: traefik-dynamic-config
+network: test
+router:
+  provider: traefik
+  config: traefik.yml
+  args:
+    dynamic-config: ./configuration
+services:
+  - service

--- a/test/samples/router/traefik-dynamic-config/service/service.yml
+++ b/test/samples/router/traefik-dynamic-config/service/service.yml
@@ -1,0 +1,3 @@
+name: service
+entrypoint: /
+image: hello-world:latest

--- a/test/samples/router/traefik-dynamic-config/traefik.yml
+++ b/test/samples/router/traefik-dynamic-config/traefik.yml
@@ -1,0 +1,3 @@
+entryPoints:
+  web:
+    address: ":80"


### PR DESCRIPTION
This adds support for a Traefik's [dynamic configuration file provider](https://doc.traefik.io/traefik/providers/file/) by allowing the configuration folder to be specified inside of a service group definition.  A new `dynamic-config` router argument is used to specifying the configuration folder location.  This folder should be in the same folder as the other services and cannot have the same name as an existing service.