### PR TITLE
Defined a simple configuration file format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ $ conda activate gantry
 
 You can verify the installation by running `gantry --version`.
 
+## Configuration
+
+> **Important:** This section is still under construction.
+
+All of *gantry*'s runtime configuration can be managed through a `gantry.yml`
+file.  Below is an example configuration:
+
+```yml
+gantry:
+    forge:
+        provider: gitea
+        url: https://gitea.example.com
+        owner: some-org
+    registry:
+        url: https://containers.example.com
+        namespace: my-namespace
+```
+
+The properties for `gitea.forge` are required in the configuration.  If a
+`gitea.registry` is not provided then it will be inferred from the forge
+configuration.
+
 ## Defining Services
 
 All host services are defined by a single [service group](#service-group).  It

--- a/src/gantry/_types.py
+++ b/src/gantry/_types.py
@@ -1,3 +1,3 @@
-import pathlib
+from pathlib import Path
 
-PathLike = pathlib.Path | str
+PathLike = Path | str

--- a/src/gantry/config.py
+++ b/src/gantry/config.py
@@ -1,10 +1,10 @@
-from typing import TypedDict, NotRequired, cast
+from typing import TypedDict, NotRequired
 
 from ruamel.yaml import YAML
 
 from ._types import PathLike
 from .exceptions import ConfigFileValidationError
-from .schemas import Schema, get_schema, validate_object
+from .schemas import Schema, validate_object
 
 
 class _ForgeConfig(TypedDict):
@@ -32,11 +32,9 @@ class Config:
         path : path-like
             the path to the configuration file
         '''
-        schema = get_schema(Schema.CONFIG)
-
         yaml = YAML()
-        contents = cast(_GantryConfig, yaml.load(path))
-        errors = validate_object(contents, schema)
+        contents = yaml.load(path)
+        errors = validate_object(contents, Schema.CONFIG)
 
         if len(errors) > 0:
             raise ConfigFileValidationError(errors)

--- a/src/gantry/config.py
+++ b/src/gantry/config.py
@@ -1,0 +1,42 @@
+from typing import TypedDict
+
+from ruamel.yaml import YAML
+
+from ._types import PathLike
+from .exceptions import ConfigFileValidationError
+from .schemas import Schema, get_schema, validate_object
+
+
+class _ForgeConfig(TypedDict):
+    provider: str
+    url: str
+    owner: str
+
+
+class _RegistryConfig(TypedDict):
+    url: str
+    namespace: str
+
+
+class _GantryConfig(TypedDict):
+    forge: _ForgeConfig
+    registry: _RegistryConfig
+
+
+class Config:
+    '''Stores the serialized Gantry configuration.'''
+    def __init__(self, path: PathLike) -> None:
+        '''
+        Parameters
+        ----------
+        path : path-like
+            the path to the configuration file
+        '''
+        schema = get_schema(Schema.CONFIG)
+
+        yaml = YAML()
+        contents = yaml.load(path)
+        errors = validate_object(contents, schema)
+
+        if len(errors) > 0:
+            raise ConfigFileValidationError(errors)

--- a/src/gantry/config.py
+++ b/src/gantry/config.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, NotRequired
 
 from ruamel.yaml import YAML
 
@@ -20,7 +20,7 @@ class _RegistryConfig(TypedDict):
 
 class _GantryConfig(TypedDict):
     forge: _ForgeConfig
-    registry: _RegistryConfig
+    registry: NotRequired[_RegistryConfig]
 
 
 class Config:
@@ -35,8 +35,10 @@ class Config:
         schema = get_schema(Schema.CONFIG)
 
         yaml = YAML()
-        contents = yaml.load(path)
+        contents: _GantryConfig = yaml.load(path)
         errors = validate_object(contents, schema)
 
         if len(errors) > 0:
             raise ConfigFileValidationError(errors)
+
+        self._contents = contents

--- a/src/gantry/exceptions/__init__.py
+++ b/src/gantry/exceptions/__init__.py
@@ -1,0 +1,7 @@
+from .service_manager import (
+    ServiceManagerException,
+    ComposeServiceBuildError,
+    InvalidServiceDefinitionError,
+    MissingTemplateError,
+    ServiceDefinitionNotFoundError
+)

--- a/src/gantry/exceptions/__init__.py
+++ b/src/gantry/exceptions/__init__.py
@@ -1,3 +1,8 @@
+from .config import (
+    ConfigException,
+    ConfigFileValidationError
+)
+
 from .service_manager import (
     ServiceManagerException,
     ComposeServiceBuildError,

--- a/src/gantry/exceptions/__init__.py
+++ b/src/gantry/exceptions/__init__.py
@@ -1,6 +1,7 @@
 from .config import (
     ConfigException,
-    ConfigFileValidationError
+    ConfigFileValidationError,
+    InvalidConfigValueError,
 )
 
 from .service_manager import (
@@ -8,5 +9,5 @@ from .service_manager import (
     ComposeServiceBuildError,
     InvalidServiceDefinitionError,
     MissingTemplateError,
-    ServiceDefinitionNotFoundError
+    ServiceDefinitionNotFoundError,
 )

--- a/src/gantry/exceptions/config.py
+++ b/src/gantry/exceptions/config.py
@@ -1,0 +1,39 @@
+from typing import NamedTuple
+
+from jsonschema.exceptions import ValidationError
+
+
+class ConfigException(Exception):
+    '''Base class for all configuration exceptions.'''
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class ConfigFileValidationError(ConfigException):
+    '''Exception raised when a configuration file failed to validate.'''
+    class ErrorInfo(NamedTuple):
+        path: str
+        message: str
+
+        def __str__(self) -> str:
+            return f'{self.path}: {self.message}'
+
+    def __init__(self, errors: list[ValidationError]) -> None:
+        '''Initialize a new definition error.
+
+        Parameters
+        ----------
+        errors : list[ValidationError]
+            a list of errors found during schema validation
+        '''
+        self._errors = [
+            ConfigFileValidationError.ErrorInfo(err.json_path, err.message)
+            for err in errors
+        ]
+        msg = str(errors[0]) if len(errors) == 1 else f'Found {len(errors)} errors in config file.'  # noqa: E501
+        super().__init__(msg)
+
+    @property
+    def errors(self) -> list[ErrorInfo]:
+        '''A list of all detected errors.'''
+        return self._errors

--- a/src/gantry/exceptions/config.py
+++ b/src/gantry/exceptions/config.py
@@ -37,3 +37,13 @@ class ConfigFileValidationError(ConfigException):
     def errors(self) -> list[ErrorInfo]:
         '''A list of all detected errors.'''
         return self._errors
+
+
+class InvalidConfigValueError(ConfigException):
+    '''Exception raised when a configuration value is invalid.
+
+    This differs from the :exc:`ConfigFileValidationError` in that it represents
+    an error parsing a value after it has been loaded from a file.
+    '''
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)

--- a/src/gantry/exceptions/service_manager.py
+++ b/src/gantry/exceptions/service_manager.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 
 from jsonschema.exceptions import ValidationError
 
-from ._types import PathLike
+from .._types import PathLike
 
 
 class ServiceManagerException(Exception):

--- a/src/gantry/schemas/__init__.py
+++ b/src/gantry/schemas/__init__.py
@@ -9,6 +9,7 @@ from jsonschema.exceptions import ValidationError
 
 class Schema(Enum):
     '''Enumeration of available schemas.'''
+    CONFIG = 'config'
     SERVICE = 'service'
     SERVICE_GROUP = 'service_group'
 

--- a/src/gantry/schemas/config.json
+++ b/src/gantry/schemas/config.json
@@ -3,12 +3,8 @@
     "$id": "/gantry/schemas/config.json",
     "title": "Gantry Configuration",
     "description": "The gantry configuration file format.",
-    "type": "object",
+    "type":"object",
     "definitions": {
-        "common": {
-            "type": "object",
-            "additionalProperties": false
-        },
         "url": {
             "type": "string",
             "format": "uri",
@@ -18,11 +14,9 @@
     "properties": {
         "gantry": {
             "description": "The gantry configuration object.",
-            "$ref": "#/definitions/common",
             "properties": {
                 "forge": {
                     "description": "Information about the software forge that gantry will connect to.",
-                    "$ref": "#/definitions/common",
                     "properties": {
                         "provider": {
                             "description": "The forge provider.",
@@ -38,11 +32,11 @@
                             "description": "The user account or organization gantry will interact with.",
                             "type": "string"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "registry": {
                     "description": "The container registery gantry will push to (optional).",
-                    "$ref": "#/definitions/common",
                     "properties": {
                         "url": {
                             "description": "URL of the container registry.",
@@ -52,13 +46,14 @@
                             "description": "The namespace applied to container images.",
                             "type": "string"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "required": ["forge"]
         }
     },
     "required": [
         "gantry"
-    ],
-    "additionalProperties": false
+    ]
 }

--- a/src/gantry/schemas/config.json
+++ b/src/gantry/schemas/config.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "/gantry/schemas/config.json",
+    "title": "Gantry Configuration",
+    "description": "The gantry configuration file format.",
+    "type": "object",
+    "definitions": {
+        "common": {
+            "type": "object",
+            "additionalProperties": false
+        },
+        "url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://"
+        }
+    },
+    "properties": {
+        "gantry": {
+            "description": "The gantry configuration object.",
+            "$ref": "#/definitions/common",
+            "properties": {
+                "forge": {
+                    "description": "Information about the software forge that gantry will connect to.",
+                    "$ref": "#/definitions/common",
+                    "properties": {
+                        "provider": {
+                            "description": "The forge provider.",
+                            "type": "string",
+                            "enum": ["gitea"],
+                            "default": "gitea"
+                        },
+                        "url": {
+                            "description": "The forge's base URL.",
+                            "$ref": "#/definitions/url"
+                        },
+                        "owner": {
+                            "description": "The user account or organization gantry will interact with.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "registry": {
+                    "description": "The container registery gantry will push to (optional).",
+                    "$ref": "#/definitions/common",
+                    "properties": {
+                        "url": {
+                            "description": "URL of the container registry.",
+                            "$ref": "#/definitions/url"
+                        },
+                        "namespace": {
+                            "description": "The namespace applied to container images.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "gantry"
+    ],
+    "additionalProperties": false
+}

--- a/test/samples/configs/basic.yml
+++ b/test/samples/configs/basic.yml
@@ -1,0 +1,5 @@
+gantry:
+  forge:
+    provider: gitea
+    url: https://gitea.example.com
+    owner: some-org

--- a/test/samples/configs/container-repo.yml
+++ b/test/samples/configs/container-repo.yml
@@ -1,0 +1,8 @@
+gantry:
+  forge:
+    provider: gitea
+    url: https://gitea.example.com
+    owner: some-org
+  registry:
+    url: https://containers.example.com
+    namespace: my-namespace

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -15,7 +15,7 @@ def test_basic_config(samples_folder: Path) -> None:
 
 
 def test_container_repo_config(samples_folder: Path) -> None:
-    yaml_file = samples_folder / 'configs' / 'basic.yml'
+    yaml_file = samples_folder / 'configs' / 'container-repo.yml'
     config = Config(yaml_file)
 
     assert config.forge_owner == 'some-org'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,26 @@
+from gantry._types import Path
+from gantry.config import Config
+
+
+def test_basic_config(samples_folder: Path) -> None:
+    yaml_file = samples_folder / 'configs' / 'basic.yml'
+    config = Config(yaml_file)
+
+    assert config.forge_owner == 'some-org'
+    assert config.forge_provider == 'gitea'
+    assert config.forge_url == 'https://gitea.example.com'
+
+    assert config.registry_namespace == 'some-org'
+    assert config.registry_url == 'https://gitea.example.com'
+
+
+def test_container_repo_config(samples_folder: Path) -> None:
+    yaml_file = samples_folder / 'configs' / 'basic.yml'
+    config = Config(yaml_file)
+
+    assert config.forge_owner == 'some-org'
+    assert config.forge_provider == 'gitea'
+    assert config.forge_url == 'https://gitea.example.com'
+
+    assert config.registry_namespace == 'my-namespace'
+    assert config.registry_url == 'https://containers.example.com'

--- a/test/test_schema_export.py
+++ b/test/test_schema_export.py
@@ -46,6 +46,7 @@ def test_schema_list():
     assert result.exit_code == 0
 
     schemas = result.output.splitlines()
-    assert len(schemas) == 2
-    assert schemas[0] == Schema.SERVICE.value
-    assert schemas[1] == Schema.SERVICE_GROUP.value
+    assert len(schemas) == 3
+    assert schemas[0] == Schema.CONFIG.value
+    assert schemas[1] == Schema.SERVICE.value
+    assert schemas[2] == Schema.SERVICE_GROUP.value


### PR DESCRIPTION
The new `Config` object and associated schema allow a gantry configuration to be loaded from a YAML file.  The current configuration is extremely simple and is mainly intended to make it possible to (eventually) interact with Gitea's [package registry](https://docs.gitea.io/en-us/usage/packages/overview/).