### PR TITLE
gantry can now authenticate with a software forge.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         run: conda run -n gantry --live-stream ./scripts/run-mypy
 
       - name: Run tests.
-        run: conda run -n gantry --live-stream pytest
+        run: conda run -n gantry --live-stream pytest -p no:legacypath
 
   build-samples:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .vscode/
 
+# Gantry-specific files
+gantry.yml
+.gantry/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "jinja2 ~= 3.1",
     "jsonschema ~= 4.17",
     "rich ~= 13.3",
-    "ruamel.yaml ~= 0.17"
+    "ruamel.yaml ~= 0.17",
+    "urllib3 ~= 2.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ version = "0.5.0"
 description = "Manager Dockerized services on single-host deployments."
 requires-python = "~=3.10"
 dependencies = [
+    "certifi == 2023.5.7",
     "click ~= 8.1",
     "docker ~= 6.1",
     "jinja2 ~= 3.1",

--- a/src/gantry/cli/_common.py
+++ b/src/gantry/cli/_common.py
@@ -11,6 +11,9 @@ from ..services import ServiceGroupDefinition
 
 
 class ProgramOptions(NamedTuple):
+    app_folder: Path
+    '''The location where the program's runtime data is stored.'''
+
     config: Config | None
     '''The program's configuration data.  Will be "None" if it isn't available.'''
 

--- a/src/gantry/cli/_main.py
+++ b/src/gantry/cli/_main.py
@@ -5,7 +5,7 @@ import click
 
 import rich
 
-from . import build, configure, schemas
+from . import build, configure, forge, schemas
 from ._common import ProgramOptions
 
 from .. import __version__
@@ -58,4 +58,5 @@ def main(ctx: click.Context, config_file: Path | None, debug: bool, logfile: Pat
 
 main.add_command(build.cmd)
 main.add_command(configure.cmd)
+main.add_command(forge.cmd)
 main.add_command(schemas.cmd)

--- a/src/gantry/cli/_main.py
+++ b/src/gantry/cli/_main.py
@@ -28,6 +28,12 @@ def _load_config_file(config_file: Path) -> Config | None:
 
 @click.group()
 @click.option(
+    '--app-folder', '-a', 'app_folder',
+    help='Gantry application folder.',
+    default='.gantry',
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path)
+)
+@click.option(
     '--config', '-c', 'config_file',
     help='Gantry configuration file.',
     default='gantry.yml',
@@ -41,7 +47,11 @@ def _load_config_file(config_file: Path) -> Config | None:
 )
 @click.version_option(version=__version__)
 @click.pass_context
-def main(ctx: click.Context, config_file: Path, debug: bool, logfile: Path | None) -> None:
+def main(ctx: click.Context,
+         app_folder: Path,
+         config_file: Path,
+         debug: bool,
+         logfile: Path | None) -> None:
     '''A container orchestrator for homelabs.'''
     logging_args: dict[str, Any] = {
         'logfile': logfile
@@ -53,6 +63,7 @@ def main(ctx: click.Context, config_file: Path, debug: bool, logfile: Path | Non
 
     init_logger(**logging_args)  # type: ignore
     ctx.obj = ProgramOptions(
+        app_folder=app_folder,
         config=_load_config_file(config_file)
     )
 

--- a/src/gantry/cli/_main.py
+++ b/src/gantry/cli/_main.py
@@ -15,8 +15,8 @@ from ..exceptions import ConfigException, CliException
 from ..logging import init_logger
 
 
-def _load_config_file(config_file: Path | None) -> Config | None:
-    if config_file is None:
+def _load_config_file(config_file: Path) -> Config | None:
+    if not config_file.exists():
         return None
 
     try:
@@ -30,7 +30,8 @@ def _load_config_file(config_file: Path | None) -> Config | None:
 @click.option(
     '--config', '-c', 'config_file',
     help='Gantry configuration file.',
-    type=click.Path(file_okay=True, dir_okay=False, path_type=Path)
+    default='gantry.yml',
+    type=click.Path(file_okay=True, dir_okay=False, exists=False, path_type=Path)
 )
 @click.option('--debug', '-d', help='Enable debugging output.', is_flag=True)
 @click.option(
@@ -40,7 +41,7 @@ def _load_config_file(config_file: Path | None) -> Config | None:
 )
 @click.version_option(version=__version__)
 @click.pass_context
-def main(ctx: click.Context, config_file: Path | None, debug: bool, logfile: Path | None) -> None:
+def main(ctx: click.Context, config_file: Path, debug: bool, logfile: Path | None) -> None:
     '''A container orchestrator for homelabs.'''
     logging_args: dict[str, Any] = {
         'logfile': logfile

--- a/src/gantry/cli/_main.py
+++ b/src/gantry/cli/_main.py
@@ -61,11 +61,15 @@ def main(ctx: click.Context,
         logging_args['log_level'] = logging.DEBUG
         logging_args['show_traceback'] = True
 
-    init_logger(**logging_args)  # type: ignore
+    logger = init_logger(**logging_args)  # type: ignore
     ctx.obj = ProgramOptions(
         app_folder=app_folder,
         config=_load_config_file(config_file)
     )
+
+    if not app_folder.exists():
+        logger.debug('Creating app folder at \'%s\'.', app_folder)
+        app_folder.mkdir(mode=0o700, parents=True)
 
 
 main.add_command(build.cmd)

--- a/src/gantry/cli/forge.py
+++ b/src/gantry/cli/forge.py
@@ -1,8 +1,12 @@
 import click
 
+from rich.prompt import Prompt
+from rich.console import Console
+
 from ._common import ProgramOptions, print_header
 from ..config import Config
-from ..exceptions import CliException
+from ..exceptions import CliException, ForgeApiOperationFailed
+from ..forge import make_client
 from ..logging import get_app_logger
 
 
@@ -45,11 +49,62 @@ def cmd(opts: ProgramOptions) -> None:
     ),
     type=str
 )
+@click.option(
+    '--user', '-u', 'username',
+    envvar='GANTRY_FORGE_USER',
+    help=(
+        'The username of the account that gantry will try and connect as.  It '
+        'will not be used if \'--api-token\' is set. This value may also be '
+        'set using the GANTRY_FORGE_USER environment variable.'
+    ),
+    type=str
+)
+@click.option(
+    '--pass', '-p', 'password',
+    envvar='GANTRY_FORGE_PASS',
+    help=(
+        'The username of the account that gantry will try and connect as.  It '
+        'will not be used if \'--api-token\' is set. This value may also be '
+        'set using the GANTRY_FORGE_PASS environment variable.'
+    )
+)
 @click.pass_obj
-def cmd_authenticate(opts: ProgramOptions, api_token: str | None) -> None:
+def cmd_authenticate(opts: ProgramOptions,
+                     api_token: str | None,
+                     username: str | None,
+                     password: str | None) -> None:
     '''Authenticate with a software forge.'''
     config = _check_config(opts)
+    client = make_client(config, opts.app_folder)
 
     if api_token is None:
         _logger.debug('API token not provided; will request from \'%s\' provider.',
                       config.forge_provider)
+
+        if username is None or password is None:
+            username = Prompt.ask(' - Username')
+            password = Prompt.ask(' - Password', password=True)
+
+        client.set_basic_auth(user=username, passwd=password)
+    else:
+        pass
+
+
+@cmd.command('version')
+@click.pass_obj
+def cmd_version(opts: ProgramOptions) -> None:
+    '''Get the version of the remote forge service.
+
+    This gets the version of the remote forge via an API call.  This call may
+    fail if gantry has not been already authenticated with the forge.
+    '''
+    config = _check_config(opts)
+    client = make_client(config, opts.app_folder)
+
+    try:
+        console = Console()
+        with console.status('[blue]Connecting to client...'):
+            version = client.get_server_version()
+        console.print(f'{client.provider_name()} - {version}')
+    except ForgeApiOperationFailed:
+        raise CliException('Failed to get version...run with \'gantry -d\' to see traceback.')

--- a/src/gantry/cli/forge.py
+++ b/src/gantry/cli/forge.py
@@ -1,0 +1,11 @@
+import click
+
+
+@click.group('forge')
+def cmd() -> None:
+    '''Interact with git repos and artifact stores.'''
+
+
+@cmd.command('auth')
+def cmd_authenticate() -> None:
+    '''Authenticate with a software forge.'''

--- a/src/gantry/cli/forge.py
+++ b/src/gantry/cli/forge.py
@@ -1,11 +1,55 @@
 import click
 
+from ._common import ProgramOptions, print_header
+from ..config import Config
+from ..exceptions import CliException
+from ..logging import get_app_logger
+
+
+_logger = get_app_logger()
+
+
+def _check_config(opts: ProgramOptions) -> Config:
+    print_header()
+    if opts.config is None:
+        raise CliException('The \'forge\' commands require a gantry config.')
+
+    _logger.debug('Forge Details')
+    _logger.debug('  Provider: %s', opts.config.forge_provider)
+    _logger.debug('       URL: %s', opts.config.forge_url)
+    _logger.debug('       Org: %s', opts.config.forge_owner)
+
+    return opts.config
+
 
 @click.group('forge')
-def cmd() -> None:
-    '''Interact with git repos and artifact stores.'''
+@click.pass_obj
+def cmd(opts: ProgramOptions) -> None:
+    '''Interact with git repos and artifact stores.
+
+    All of the 'forge' subcommands require a gantry configuration file.  The
+    configuration file specifies the forge's URL and the account/organization
+    it will be working with.
+    '''
 
 
 @cmd.command('auth')
-def cmd_authenticate() -> None:
+@click.option(
+    '--api-token', '-a',
+    metavar='API_TOKEN',
+    envvar='GANTRY_FORGE_API_TOKEN',
+    help=(
+        'The API token used to authenticate with the forge.  Gantry is able to '
+        'automatically obtain this for some forge providers.  This value can '
+        'also be set with the GANTRY_FORGE_API_TOKEN environment variable.'
+    ),
+    type=str
+)
+@click.pass_obj
+def cmd_authenticate(opts: ProgramOptions, api_token: str | None) -> None:
     '''Authenticate with a software forge.'''
+    config = _check_config(opts)
+
+    if api_token is None:
+        _logger.debug('API token not provided; will request from \'%s\' provider.',
+                      config.forge_provider)

--- a/src/gantry/cli/forge.py
+++ b/src/gantry/cli/forge.py
@@ -58,27 +58,30 @@ def cmd(opts: ProgramOptions) -> None:
 @cmd.command('auth')
 @click.option(
     '--api-token', '-a',
-    metavar='API_TOKEN',
+    metavar='TOKEN',
     envvar='GANTRY_FORGE_API_TOKEN',
     help=(
-        'The API token used to authenticate with the forge.  Gantry is able to '
-        'automatically obtain this for some forge providers.'
+        'An API token that is used to access the forge.  Depending on the '
+        'provider, the token may require specific scopes/permissions to work '
+        'correctly.'
     ),
     type=str
 )
 @click.option(
     '--user', '-u', 'username',
+    metavar='USERNAME',
     envvar='GANTRY_FORGE_USER',
     help=(
-        'The username of the account that gantry will try and connect as.'
+        'An account user name.  Required for Basic authentication.'
     ),
     type=str
 )
 @click.option(
     '--pass', '-p', 'password',
+    metavar='PASSWORD',
     envvar='GANTRY_FORGE_PASS',
     help=(
-        'The password of the account that gantry will try and connect as.'
+        'An account password.  Required for Basic authentication.'
     )
 )
 @click.option(
@@ -86,8 +89,8 @@ def cmd(opts: ProgramOptions) -> None:
     multiple=True,
     help=(
         'Specify a custom TLS certificate to use with the forge provider.  '
-        'This may be used multiple times if a chain of certificates need to be '
-        'specified.'
+        'This may be used multiple times if a chain of certificates needs to '
+        'be specified.'
     ),
     type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True, path_type=Path)
 )

--- a/src/gantry/exceptions/__init__.py
+++ b/src/gantry/exceptions/__init__.py
@@ -9,6 +9,9 @@ from .config import (
 from .forge import (
     ForgeError,
     CannotObtainForgeAuthError,
+    ForgeApiOperationFailed,
+    ForgeOperationNotSupportedError,
+    ForgeUrlInvalidError,
 )
 
 from .images import (

--- a/src/gantry/exceptions/__init__.py
+++ b/src/gantry/exceptions/__init__.py
@@ -6,6 +6,11 @@ from .config import (
     InvalidConfigValueError,
 )
 
+from .forge import (
+    ForgeError,
+    CannotObtainForgeAuthError,
+)
+
 from .images import (
     ImageTargetException,
     ClientConnectionError,

--- a/src/gantry/exceptions/forge.py
+++ b/src/gantry/exceptions/forge.py
@@ -1,0 +1,8 @@
+class ForgeError(Exception):
+    '''Base exception for errors thrown when working with software forges.'''
+
+
+class CannotObtainForgeAuthError(ForgeError):
+    '''Thrown when the forge authentication information cannot be access.'''
+    def __init__(self, forge_ident: str) -> None:
+        super().__init__(f'Cannot load auth info for \'{forge_ident}\' forge provider.')

--- a/src/gantry/exceptions/forge.py
+++ b/src/gantry/exceptions/forge.py
@@ -1,8 +1,33 @@
 class ForgeError(Exception):
     '''Base exception for errors thrown when working with software forges.'''
+    def __init__(self, forge: str, msg: str) -> None:
+        self._forge = forge
+        super().__init__(f'{forge} :: {msg}')
+
+    @property
+    def forge(self) -> str:
+        return self._forge
 
 
 class CannotObtainForgeAuthError(ForgeError):
     '''Thrown when the forge authentication information cannot be access.'''
     def __init__(self, forge_ident: str) -> None:
-        super().__init__(f'Cannot load auth info for \'{forge_ident}\' forge provider.')
+        super().__init__(forge_ident, 'Cannot load auth info.')
+
+
+class ForgeApiOperationFailed(ForgeError):
+    '''Thrown when an API operation has failed.'''
+    def __init__(self, forge_ident: str, msg: str) -> None:
+        super().__init__(forge_ident, msg)
+
+
+class ForgeOperationNotSupportedError(ForgeError):
+    '''Thrown when the request operation is not supported for this particular forge client.'''
+    def __init__(self, forge_ident: str, msg: str) -> None:
+        super().__init__(forge_ident, msg)
+
+
+class ForgeUrlInvalidError(ForgeError):
+    '''Thrown when the URL for a forge is invalid.'''
+    def __init__(self, forge: str, url: str) -> None:
+        super().__init__(forge, f'\'{url}\' must be a valid URL and use \'https\'.')

--- a/src/gantry/forge/__init__.py
+++ b/src/gantry/forge/__init__.py
@@ -1,8 +1,15 @@
+from typing import Type
+
 from .client import AuthType, ForgeAuth, ForgeClient
 from .gitea import GiteaClient
 
 from ..config import Config as _Config
 from .._types import Path as _Path
+
+
+CLIENTS: dict[str, Type[ForgeClient]] = {
+    GiteaClient.provider_name(): GiteaClient
+}
 
 
 def make_client(config: _Config, app_folder: _Path) -> ForgeClient:
@@ -20,8 +27,7 @@ def make_client(config: _Config, app_folder: _Path) -> ForgeClient:
     :class:`ForgeClient`
         a new client, based on the provided configuration
     '''
-    match config.forge_provider:
-        case 'gitea':
-            return GiteaClient(app_folder, config.forge_url)
+    if client_type := CLIENTS.get(config.forge_provider):
+        return client_type(app_folder, config.forge_url)
 
-    raise ValueError(f'Cannot find a \'{config.forge_provider}\' client.')
+    raise KeyError(f'Cannot find a \'{config.forge_provider}\' client.')

--- a/src/gantry/forge/__init__.py
+++ b/src/gantry/forge/__init__.py
@@ -1,0 +1,1 @@
+from .client import AuthType, ForgeAuth, ForgeClient

--- a/src/gantry/forge/__init__.py
+++ b/src/gantry/forge/__init__.py
@@ -1,1 +1,27 @@
 from .client import AuthType, ForgeAuth, ForgeClient
+from .gitea import GiteaClient
+
+from ..config import Config as _Config
+from .._types import Path as _Path
+
+
+def make_client(config: _Config, app_folder: _Path) -> ForgeClient:
+    '''Create a new client given the application configuration.
+
+    Parameters
+    ----------
+    config : :class:`Config`
+        the applicatio configuration
+    app_folder : path
+        application storage folder
+
+    Returns
+    -------
+    :class:`ForgeClient`
+        a new client, based on the provided configuration
+    '''
+    match config.forge_provider:
+        case 'gitea':
+            return GiteaClient(app_folder, config.forge_url)
+
+    raise ValueError(f'Cannot find a \'{config.forge_provider}\' client.')

--- a/src/gantry/forge/client.py
+++ b/src/gantry/forge/client.py
@@ -1,0 +1,144 @@
+from abc import ABC, abstractmethod
+from enum import StrEnum
+import json
+from typing import TypedDict, NotRequired
+
+import urllib3
+import urllib3.exceptions
+import urllib3.util
+
+from .._types import Path
+from ..exceptions import (
+    CannotObtainForgeAuthError,
+    ForgeOperationNotSupportedError,
+    ForgeUrlInvalidError
+)
+from ..logging import get_app_logger
+
+
+_logger = get_app_logger('forge')
+
+
+class AuthType(StrEnum):
+    '''The authentication types for connecting to a forge.'''
+    BASIC = 'basic'
+    TOKEN = 'token'
+
+
+class ForgeAuth(TypedDict):
+    '''A dictionary used to store all necessary authentication details.'''
+    api_token: NotRequired[str]
+    auth_type: AuthType
+    username: NotRequired[str]
+    password: NotRequired[str]
+
+
+class ForgeClient(ABC):
+    '''A client to access a software forge.
+
+    The :class:`ForgeClient` allows gantry to perform a set of basic operations
+    with a software forge, such as authentication and pushing up container
+    images.  Some clients can also obtain API authentication credentials as part
+    of the authentication process.
+    '''
+    def __init__(self, app_folder: Path, url: str) -> None:
+        '''
+        Parameters
+        ----------
+        app_folder : path
+            gantry's working folder
+        '''
+        provider_folder = app_folder / self.provider_name()
+        self._auth_file = provider_folder / 'auth.json'
+
+        try:
+            self._url = urllib3.util.parse_url(url)
+        except urllib3.exceptions.LocationValueError as e:
+            raise ForgeUrlInvalidError(self.provider_name(), url) from e
+
+        if not self._url.scheme == 'https':
+            raise ForgeUrlInvalidError(self.provider_name(), url)
+
+        if not provider_folder.exists():
+            _logger.debug('Creating \'%s\'.', provider_folder)
+            provider_folder.mkdir(mode=0o700, parents=True)
+
+        self._auth_info = self._load_auth_info(self._auth_file)
+        self._http = urllib3.PoolManager()
+
+    def request_api_token(self) -> None:
+        '''Request an API token from the forge.
+
+        The client must already have some stored authentication credentials,
+        e.g. basic auth user name and password, before this call can be made.
+
+        Raises
+        ------
+        :class:`ForgeAPIOperationFailed`
+            when an API operation has failed
+        '''
+        _logger.debug('Requesting \'%s\' API token from provider at \'%s\'.',
+                      self.provider_name(),
+                      self._url)
+        self._auth_info = self._get_new_api_token()
+        self._store_auth_info(self._auth_file, self._auth_info)
+
+    def set_basic_auth(self, *, user: str, passwd: str) -> None:
+        '''Set the client to connect using HTTP basic authentication.
+
+        Parameters
+        ----------
+        user : str
+            username
+        passwd : str
+            password
+        '''
+        self._auth_info = ForgeAuth(auth_type=AuthType.BASIC, username=user, password=passwd)
+        self._store_auth_info(self._auth_file, self._auth_info)
+
+    def set_token_auth(self, *, api_token: str) -> None:
+        '''Set the client to connect using token authentication.
+
+        The exact meaning of "token authentication" will be specific to the
+        individual client.
+
+        Parameters
+        ----------
+        api_token : str
+            API tokent
+        '''
+        self._auth_info = ForgeAuth(auth_type=AuthType.TOKEN, api_token=api_token)
+        self._store_auth_info(self._auth_file, self._auth_info)
+
+    @staticmethod
+    @abstractmethod
+    def provider_name() -> str:
+        '''The provider that this client connects to.'''
+
+    def _get_new_api_token(self) -> ForgeAuth:
+        '''Obtain a new API token from a forge.
+
+        This should be overridden by a subclass if the operation is supported.
+        '''
+        raise ForgeOperationNotSupportedError(
+            self.provider_name(),
+            "This forge does not support requesting API tokens.")
+
+    @classmethod
+    def _load_auth_info(cls, auth_file: Path) -> ForgeAuth:
+        try:
+            with auth_file.open('rt') as f:
+                contents = json.load(f)
+        except FileNotFoundError:
+            contents = ForgeAuth(auth_type=AuthType.BASIC)
+            with auth_file.open('wt') as f:
+                json.dump(contents, f)
+        except PermissionError:
+            raise CannotObtainForgeAuthError(cls.provider_name())
+
+        return contents
+
+    @classmethod
+    def _store_auth_info(cls, auth_file: Path, auth_info: ForgeAuth) -> None:
+        with auth_file.open('wt') as f:
+            json.dump(auth_info, f)

--- a/src/gantry/forge/gitea.py
+++ b/src/gantry/forge/gitea.py
@@ -1,0 +1,54 @@
+from urllib.parse import urljoin
+
+from urllib3.exceptions import RequestError
+from urllib3.util import Url, parse_url
+
+from .client import AuthType, ForgeAuth, ForgeClient
+from .._types import Path
+from ..exceptions import ForgeApiOperationFailed
+from ..logging import get_app_logger
+
+
+_logger = get_app_logger('gitea')
+
+
+class GiteaClient(ForgeClient):
+    '''Push service images and definitions to a Gitea repo.'''
+    API_BASE_URL = '/api/v1'
+
+    def __init__(self, app_folder: Path, url: str) -> None:
+        super().__init__(app_folder, url)
+        self._endpoint = urljoin(url, GiteaClient.API_BASE_URL)
+
+    @property
+    def endpoint(self) -> Url:
+        return parse_url(self._endpoint)
+
+    def get_server_version(self) -> str:
+        try:
+            resp = self._http.request('GET', self._version_endpoint, headers=self._headers)
+        except RequestError as e:
+            _logger.exception('HTTP request failed.', exc_info=e)
+            raise ForgeApiOperationFailed(self.provider_name(), 'Initial HTTP request failed.') from e
+
+        if resp.status != 200:
+            raise ForgeApiOperationFailed(
+                self.provider_name(),
+                f'Operation failed with {resp.status}.'
+            )
+        return resp.json()['version']
+
+    # def _get_new_api_token(self) -> ForgeAuth:
+    #     if self._auth_info['auth_type'] != AuthType.BASIC:
+    #         raise ForgeApiOperationFailed(
+    #             self.provider_name(),
+    #             'Gitea token requests require the use of HTTP Basic authentication.'
+    #         )
+
+    @staticmethod
+    def provider_name() -> str:
+        return 'gitea'
+
+    @property
+    def _version_endpoint(self) -> str:
+        return urljoin(self._endpoint, 'version')

--- a/src/gantry/forge/gitea.py
+++ b/src/gantry/forge/gitea.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 from urllib3.exceptions import RequestError
 from urllib3.util import Url, parse_url
 
-from .client import AuthType, ForgeAuth, ForgeClient
+from .client import ForgeClient
 from .._types import Path
 from ..exceptions import ForgeApiOperationFailed
 from ..logging import get_app_logger
@@ -14,7 +14,7 @@ _logger = get_app_logger('gitea')
 
 class GiteaClient(ForgeClient):
     '''Push service images and definitions to a Gitea repo.'''
-    API_BASE_URL = '/api/v1'
+    API_BASE_URL = '/api/v1/'
 
     def __init__(self, app_folder: Path, url: str) -> None:
         super().__init__(app_folder, url)
@@ -26,10 +26,14 @@ class GiteaClient(ForgeClient):
 
     def get_server_version(self) -> str:
         try:
+            _logger.debug('Requesting version from \'%s\'.', self._version_endpoint)
             resp = self._http.request('GET', self._version_endpoint, headers=self._headers)
         except RequestError as e:
             _logger.exception('HTTP request failed.', exc_info=e)
-            raise ForgeApiOperationFailed(self.provider_name(), 'Initial HTTP request failed.') from e
+            raise ForgeApiOperationFailed(
+                self.provider_name(),
+                'Initial HTTP request failed.'
+            ) from e
 
         if resp.status != 200:
             raise ForgeApiOperationFailed(
@@ -38,13 +42,6 @@ class GiteaClient(ForgeClient):
             )
 
         return resp.json()['version']
-
-    # def _get_new_api_token(self) -> ForgeAuth:
-    #     if self._auth_info['auth_type'] != AuthType.BASIC:
-    #         raise ForgeApiOperationFailed(
-    #             self.provider_name(),
-    #             'Gitea token requests require the use of HTTP Basic authentication.'
-    #         )
 
     @staticmethod
     def provider_name() -> str:

--- a/src/gantry/forge/gitea.py
+++ b/src/gantry/forge/gitea.py
@@ -36,6 +36,7 @@ class GiteaClient(ForgeClient):
                 self.provider_name(),
                 f'Operation failed with {resp.status}.'
             )
+
         return resp.json()['version']
 
     # def _get_new_api_token(self) -> ForgeAuth:

--- a/test/test_forge.py
+++ b/test/test_forge.py
@@ -1,9 +1,9 @@
 import json
 from pathlib import Path
 import stat
-
 from urllib.parse import urljoin
-import urllib3.util
+
+from urllib3.util import Url, parse_url
 
 from gantry import __version__ as gantry_version
 from gantry.exceptions import ForgeUrlInvalidError, ForgeOperationNotSupportedError
@@ -22,8 +22,11 @@ class MockForge(ForgeClient):
         super().__init__(app_folder, url)
 
     @property
-    def endpoint(self) -> urllib3.util.Url:
-        return urllib3.util.parse_url(urljoin(self._url.url, '/api/v1/mock'))
+    def endpoint(self) -> Url:
+        return parse_url(urljoin(self._url.url, '/api/v1/mock'))
+
+    def get_server_version(self) -> str:
+        return 'n/a'
 
     @staticmethod
     def provider_name() -> str:

--- a/test/test_forge.py
+++ b/test/test_forge.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+import stat
+
+from gantry.exceptions import ForgeUrlInvalidError, ForgeOperationNotSupportedError
+from gantry.forge import AuthType, ForgeAuth, ForgeClient
+
+import pytest
+
+
+class MockForge(ForgeClient):
+    def __init__(self,
+                 app_folder: Path,
+                 *,
+                 url: str = 'https://localhost',
+                 requests_token: bool = False) -> None:
+        self._requests_token = requests_token
+        super().__init__(app_folder, url)
+
+    @staticmethod
+    def provider_name() -> str:
+        return 'mock'
+
+    def _get_new_api_token(self) -> ForgeAuth:
+        if self._requests_token:
+            return ForgeAuth(auth_type=AuthType.TOKEN, api_token='54321')
+        else:
+            return super()._get_new_api_token()
+
+
+def test_create_new_forge(tmp_path: Path) -> None:
+    mock = MockForge(tmp_path)
+    auth_file = tmp_path / 'mock' / 'auth.json'
+
+    assert auth_file.exists()
+    assert mock._auth_file == auth_file
+
+    # Directory should have 0700 (only user read/write/execute) permissions.
+    info = mock._auth_file.parent.stat()
+    mode = (
+        info.st_mode & stat.S_IRWXU |
+        info.st_mode & stat.S_IRWXG |
+        info.st_mode & stat.S_IRWXO
+    )
+    assert mode == 0o700
+
+    # The auth.json file for a new forge client should be 'basic' with no other
+    # information.
+    with mock._auth_file.open('rt') as f:
+        obj = json.load(f)
+        assert obj == ForgeAuth(auth_type=AuthType.BASIC)
+
+
+def test_load_existing_auth_info(tmp_path: Path) -> None:
+    auth_file = tmp_path / 'mock' / 'auth.json'
+    auth_file.parent.mkdir(mode=0o700, parents=True)
+    with auth_file.open('wt') as f:
+        json.dump(ForgeAuth(api_token='123456', auth_type=AuthType.TOKEN), f)
+
+    mock = MockForge(tmp_path)
+    assert mock._auth_info['auth_type'] == AuthType.TOKEN
+    assert mock._auth_info['api_token'] == '123456'
+
+
+def test_set_basic_auth(tmp_path: Path) -> None:
+    mock = MockForge(tmp_path)
+    mock.set_basic_auth(user='abc', passwd='def')
+
+    with mock._auth_file.open('rt') as f:
+        info = json.load(f)
+
+    assert info['auth_type'] == AuthType.BASIC
+    assert info['username'] == 'abc'
+    assert info['password'] == 'def'
+
+
+def test_set_token_auth(tmp_path: Path) -> None:
+    mock = MockForge(tmp_path)
+    mock.set_token_auth(api_token='123456')
+
+    with mock._auth_file.open('rt') as f:
+        info = json.load(f)
+
+    assert info['auth_type'] == AuthType.TOKEN
+    assert info['api_token'] == '123456'
+
+
+@pytest.mark.parametrize('url', ('localhost', 'localhost:999999'))
+def test_error_on_invalid_url(url: str, tmp_path: Path) -> None:
+    with pytest.raises(ForgeUrlInvalidError):
+        MockForge(tmp_path, url=url)
+
+    auth_file = tmp_path / 'mock' / 'auth.json'
+    assert not auth_file.exists()
+
+
+def test_error_when_request_api_not_supported(tmp_path: Path) -> None:
+    mock = MockForge(tmp_path, requests_token=False)
+    with pytest.raises(ForgeOperationNotSupportedError,
+                       match='This forge does not support requesting API tokens.'):
+        mock.request_api_token()
+
+
+def test_correct_behavior_when_request_api_supported(tmp_path: Path) -> None:
+    mock = MockForge(tmp_path, requests_token=True)
+    mock.request_api_token()
+
+    with mock._auth_file.open('rt') as f:
+        info = json.load(f)
+
+    assert info['auth_type'] == AuthType.TOKEN
+    assert info['api_token'] == '54321'
+    assert info == mock._auth_info


### PR DESCRIPTION
The new `gantry forge` command allows gantry to work with a software forge such as a [Gitea](https://gitea.io/).  The `forge auth` command allows gantry to setup the authentication credentials either with HTTP Basic authentication (username and password) or API tokens.  The `forge version` command allows gantry to request some version info from the forge, though this will depend on the forge provider.

Only Gitea is supported as a forge provider at this time.