### PR TITLE
Use the correct location for storing the Traefik config in a container.

### DIFF
--- a/src/gantry/routers/traefik/proxy-service.yml
+++ b/src/gantry/routers/traefik/proxy-service.yml
@@ -16,7 +16,7 @@ files:
     external: "./{{ dynamic_config.name }}"
   {% endif %}
   static-config:
-    internal: /traefik.yml
+    internal: /etc/traefik/traefik.yml
     external: "./{{ config_file }}"
 service-ports:
   http:

--- a/test/test_traefik_router.py
+++ b/test/test_traefik_router.py
@@ -30,7 +30,7 @@ def test_router_config_render(compile_services: ServicesFn):
         compose_spec: ComposeFile = reader.load(f)
 
     volumes = compose_spec['services']['proxy']['volumes']
-    assert volumes[1] == './traefik-custom.yml:/traefik.yml:ro'
+    assert volumes[1] == './traefik-custom.yml:/etc/traefik/traefik.yml:ro'
 
 
 def test_router_dynamic_config(compile_services: ServicesFn):
@@ -97,4 +97,4 @@ def test_router_socket(sample: str, expected: str, compile_compose_file: Compile
     compose_spec = compile_compose_file('router', sample)
     volumes = compose_spec['services']['proxy']['volumes']
     assert volumes[0] == f'{expected}:/var/run/docker.sock:ro'
-    assert volumes[1] == './traefik.yml:/traefik.yml:ro'
+    assert volumes[1] == './traefik.yml:/etc/traefik/traefik.yml:ro'


### PR DESCRIPTION
The Traefik config was being mounted to `/traefik.yml` instead of one of the [supported locations](https://github.com/traefik/traefik/blob/0a7964300166d167f68d5502bc245b3b9c8842b4/pkg/cli/loader_file.go#L68).  The static config will now be mounted in `/etc/traefik/traefik.yml`.