### PR TITLE
Allow container health checks to be disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ volumes:
     internal-storage: /storage
 ```
 
+Lastly, any container healthchecks can be disabled by setting the `healthcheck`
+property to `false`:
+
+```yaml
+name: disabled-health-check
+image: image-with-unnecessary-health-check:v123
+healthcheck: false
+```
+
+The default is set to `true` since modifying or disabling a healthcheck can best
+be done by customizing the container image.
+
 The following variables are defined when a service definition is being
 processed:
 

--- a/src/gantry/_compose_spec.py
+++ b/src/gantry/_compose_spec.py
@@ -15,10 +15,21 @@ class ComposeBuild(_ComposeBase, total=False):
     dockerfile: str
 
 
+class ComposeHealthcheck(_ComposeBase, total=False):
+    test: list[str] | str
+    interval: str
+    timeout: str
+    retries: int
+    start_period: str
+    start_interval: str
+    disable: bool
+
+
 class ComposeService(_ComposeBase, total=False):
     build: ComposeBuild
     container_name: str
     environment: dict[str, str]
+    healthcheck: ComposeHealthcheck
     image: str
     labels: dict[str, str | int | bool]
     networks: list[str]

--- a/src/gantry/schemas/service.json
+++ b/src/gantry/schemas/service.json
@@ -122,6 +122,11 @@
                 "$ref": "#/definitions/fileMapping"
             }
         },
+        "healthcheck": {
+            "title": "Container Healthcheck",
+            "description": "Enable/disable the container's healthcheck.  If 'false' it will disable the container's healthcheck, which can be useful if a container has a healthcheck but isn't required.",
+            "type": "boolean"
+        },
         "image": {
             "title": "Docker/Container Image",
             "description": "The image to pull from a container repo (usually Docker Hub).  Cannot be used with 'build-args'.",

--- a/src/gantry/services.py
+++ b/src/gantry/services.py
@@ -167,6 +167,11 @@ class ServiceDefinition(_ServiceDefinitionBase):
         return {ref: PathMapping(details) for ref, details in file_mapping.items()}
 
     @property
+    def healthcheck(self) -> bool:
+        '''Indicate if a container's health checks should be enabled or disabled.'''
+        return self._definition.get('healthcheck', True)
+
+    @property
     def image(self) -> str | None:
         '''The name of the container image.  Mutually exclusive with :attr:`build_args`.'''
         return self._definition.get('image')

--- a/src/gantry/targets/compose.py
+++ b/src/gantry/targets/compose.py
@@ -77,6 +77,9 @@ def _convert_to_compose_service(service: ServiceDefinition,
     compose_service['volumes'].extend(str(f) for f in service.files.values())
     compose_service['volumes'].extend(f'{k}:{v}' for k, v in service.volumes.items())
 
+    if not service.healthcheck:
+        compose_service['healthcheck']['disable'] = True
+
     if metadata := service.metadata:
         compose_service['labels'] = metadata
 

--- a/src/gantry/targets/compose.py
+++ b/src/gantry/targets/compose.py
@@ -78,7 +78,7 @@ def _convert_to_compose_service(service: ServiceDefinition,
     compose_service['volumes'].extend(f'{k}:{v}' for k, v in service.volumes.items())
 
     if not service.healthcheck:
-        compose_service['healthcheck']['disable'] = True
+        compose_service['healthcheck'] = {'disable': True}
 
     if metadata := service.metadata:
         compose_service['labels'] = metadata

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import traceback
 from typing import Callable
 
 import click
@@ -24,6 +25,8 @@ def compile_compose_file(samples_folder: Path, tmp_path: Path) -> Callable[[str,
             compose_file = Path(td) / 'build' / 'services.compose' / sample / 'docker-compose.yml'
 
             click.echo(result.stdout)
+            if result.exception is not None:
+                traceback.print_exception(*result.exc_info)
             assert result.exit_code == 0
             assert compose_file.exists()
 

--- a/test/samples/service-definition/healthcheck/disabled/service.yml
+++ b/test/samples/service-definition/healthcheck/disabled/service.yml
@@ -1,0 +1,2 @@
+name: disabled
+healthcheck: false

--- a/test/samples/service-definition/healthcheck/service.yml
+++ b/test/samples/service-definition/healthcheck/service.yml
@@ -1,0 +1,7 @@
+name: healthcheck
+network: test
+router:
+  provider: traefik
+  config: traefik.yml
+services:
+  - disabled

--- a/test/samples/service-definition/healthcheck/traefik.yml
+++ b/test/samples/service-definition/healthcheck/traefik.yml
@@ -1,0 +1,3 @@
+entryPoints:
+  web:
+    address: ":80"

--- a/test/test_service_definition.py
+++ b/test/test_service_definition.py
@@ -64,3 +64,8 @@ def test_collection_interface(samples_folder: Path) -> None:
     assert list(service.name for service in service_group) == expected
     for service in expected:
         assert service in service_group
+
+
+def test_disable_healthcheck(compile_compose_file: CompileFn) -> None:
+    compose_file = compile_compose_file('service-definition', 'healthcheck')
+    assert compose_file['services']['disabled']['healthcheck']['disable'] is True


### PR DESCRIPTION
The new `healthcheck` service property allows container health checks to be selectively disabled.  This is intend for cases where there is a desire to disable a health check without creating a custom container image.