### PR TITLE
Remove `flit` as a build dependency.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Build a new release.
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   release:
     types:
       - published
@@ -51,6 +55,7 @@ jobs:
   update-release:
     name: Attach artifacts to release.
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' }}
     needs:
       - build-dist
       - generate-schemas

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
-  pull_request:
   release:
     types:
       - published
+  pull_request:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   build-dist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run 'flit build' to generate source distribution and Python wheel.
+      - name: Run 'build' to generate source distribution and Python wheel.
         run: |
           conda env create
-          conda run -n gantry --live-stream pip install --upgrade pip setuptools
-          conda run -n gantry --live-stream flit build --setup-py
+          conda run -n gantry --live-stream pip install --upgrade pip setuptools build
+          conda run -n gantry --live-stream python -m build --sdist --wheel
 
       - name: Upload build artifacts.
         uses: actions/upload-artifact@v3
@@ -35,7 +35,7 @@ jobs:
         run: |
           conda env create
           conda run -n gantry --live-stream pip install --upgrade pip setuptools
-          conda run -n gantry --live-stream flit install
+          conda run -n gantry --live-stream pip install .
           conda run -n gantry --live-stream gantry schemas export
 
       - name: Create schemas archive.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build gantry release.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run 'build' to generate source distribution and Python wheel.
         run: |
@@ -23,7 +23,7 @@ jobs:
           conda run -n gantry --live-stream python -m build --sdist --wheel
 
       - name: Upload build artifacts.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: dist
@@ -33,7 +33,7 @@ jobs:
     name: Generate JSON schema package.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Export the JSON schemas from gantry.
         run: |
@@ -46,7 +46,7 @@ jobs:
         run: tar -czvf schemas.tar.gz schemas
 
       - name: Upload build artifacts.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: schemas
           path: schemas.tar.gz
@@ -60,10 +60,10 @@ jobs:
       - build-dist
       - generate-schemas
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download build artifacts.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Parse version tag.
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format-code
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup conda environment and install gantry.
         run: |
@@ -59,7 +59,7 @@ jobs:
           - simple-tls
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build and install gantry.
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           conda env create
           conda run -n gantry --live-stream pip install --upgrade pip setuptools
-          conda run -n gantry --live-stream flit install
+          conda run -n gantry --live-stream pip install .
 
       - name: Build '${{ matrix.sample }}'' sample.
         run: |

--- a/README.md
+++ b/README.md
@@ -7,22 +7,23 @@ how they're deployed (docker-compose, podman, etc.).
 ## Installation
 
 The best way to install *gantry* is to use the provided
-[conda](https://docs.conda.io/en/latest/) environment file.  It requires Python
-3.10 and [flit](https://flit.pypa.io/en/latest/pyproject_toml.html), which the
-environment file is already set up for.  Installing into a conda environment is
-done by
+[conda](https://docs.conda.io/en/latest/) environment file.
 
 ```bash
 $ conda env create
 $ conda activate gantry
-(gantry) $ flit install
+(gantry) $ pip install .
 ```
+
+> [!TIP]
+> The development dependencies can be installed with `pip install .[dev]`.
 
 You can verify the installation by running `gantry --version`.
 
 ## Configuration
 
-> **Important:** This section is still under construction.
+> [!NOTE]
+> This section is still under construction.
 
 All of *gantry*'s runtime configuration can be managed through a `gantry.yml`
 file.  Below is an example configuration:

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - python=3.11
   - pip
   - pip:
-    - flit
+    - setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Richard Rzeszutek"}]
 readme = "README.md"
 version = "0.6.0"
 description = "Manager Dockerized services on single-host deployments."
-requires-python = "~=3.10"
+requires-python = "==3.11.*"
 dependencies = [
     "certifi == 2023.7.22",
     "click == 8.1.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,8 @@ dev = [
 [project.scripts]
 gantry = "gantry.cli:main"
 
-[tool.flit.sdist]
-exclude=[".github", "scripts"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"gantry.schemas" = ["*.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "gantry"
 authors = [{name = "Richard Rzeszutek"}]
 readme = "README.md"
-version = "0.5.0"
+version = "0.6.0"
 description = "Manager Dockerized services on single-host deployments."
 requires-python = "~=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "gantry"


### PR DESCRIPTION
This removes `flit` as a build dependency and instead switches to `setuptools`.  